### PR TITLE
impl ResultSetMetaData.getColumnLabel + fix getInstance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <optional>true</optional>

--- a/src/main/java/com/vesoft/nebula/jdbc/NebulaResultSetMetaData.java
+++ b/src/main/java/com/vesoft/nebula/jdbc/NebulaResultSetMetaData.java
@@ -12,25 +12,14 @@ import java.util.List;
 
 public class NebulaResultSetMetaData implements ResultSetMetaData {
 
-    private NebulaResultSet nebulaResultSet;
-    private static NebulaResultSetMetaData nebulaResultSetMetaData = null;
+    private final NebulaResultSet nebulaResultSet;
 
     private NebulaResultSetMetaData(NebulaResultSet nebulaResultSet) {
         this.nebulaResultSet = nebulaResultSet;
     }
 
     public static NebulaResultSetMetaData getInstance(NebulaResultSet nebulaResultSet) {
-        if (nebulaResultSetMetaData == null) {
-            nebulaResultSetMetaData = new NebulaResultSetMetaData(nebulaResultSet);
-        }
-        return nebulaResultSetMetaData;
-    }
-
-    /**
-     * If you want to get MetaData after ResultSet changes, the method below should be called.
-     */
-    public static void release() {
-        nebulaResultSetMetaData = null;
+        return new NebulaResultSetMetaData(nebulaResultSet);
     }
 
     @Override
@@ -102,7 +91,7 @@ public class NebulaResultSetMetaData implements ResultSetMetaData {
 
     @Override
     public String getColumnLabel(int column) throws SQLException {
-        throw ExceptionBuilder.buildUnsupportedOperationException();
+        return getColumnName(column);
     }
 
     @Override

--- a/src/test/java/com/vesoft/nebula/jdbc/NebulaResultSetMetaDataTest.java
+++ b/src/test/java/com/vesoft/nebula/jdbc/NebulaResultSetMetaDataTest.java
@@ -1,0 +1,50 @@
+package com.vesoft.nebula.jdbc;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+class NebulaResultSetMetaDataTest {
+
+	@Test
+	void testGetColumnName() throws SQLException {
+		NebulaResultSet resultSet = mock(NebulaResultSet.class);
+		List<String> columnNames = Stream.of("col1", "col2").collect(Collectors.toList());
+		doReturn(columnNames).when(resultSet).getColumnNames();
+
+		NebulaResultSetMetaData metadata = NebulaResultSetMetaData.getInstance(resultSet);
+		assertEquals("col1", metadata.getColumnName(1));
+		assertEquals("col2", metadata.getColumnName(2));
+		assertThrows(SQLException.class, () -> metadata.getColumnName(3));
+	}
+
+	@Test
+	void testGetColumnLabel() throws SQLException {
+		NebulaResultSet resultSet = mock(NebulaResultSet.class);
+		List<String> columnNames = Stream.of("col1", "col2").collect(Collectors.toList());
+		doReturn(columnNames).when(resultSet).getColumnNames();
+
+		NebulaResultSetMetaData metadata = NebulaResultSetMetaData.getInstance(resultSet);
+		assertEquals("col1", metadata.getColumnName(1));
+		assertEquals("col2", metadata.getColumnName(2));
+		assertThrows(SQLException.class, () -> metadata.getColumnName(3));
+	}
+
+	@Test
+	void testGetInstanceDiffResultSets() {
+		NebulaResultSet resultSet1 = mock(NebulaResultSet.class);
+		NebulaResultSet resultSet2 = mock(NebulaResultSet.class);
+		assertNotEquals(resultSet1, resultSet2);
+
+		NebulaResultSetMetaData metaData1 = NebulaResultSetMetaData.getInstance(resultSet1);
+		NebulaResultSetMetaData metaData2 = NebulaResultSetMetaData.getInstance(resultSet2);
+		assertNotEquals(metaData1, metaData2);
+	}
+
+}


### PR DESCRIPTION
ResultSetMedatada.getColumnLabel() is used in spring's DataClassRowMapper:
https://github.com/spring-projects/spring-framework/blob/a13cb01b992a9fd74d1b6fd4e34c444bdf5a2d83/spring-jdbc/src/main/java/org/springframework/jdbc/support/JdbcUtils.java#L505

Plus fix returning same metadata on different resultsets:
Doesn't make sense to cache NebulaResultSetMetaData into a static variable, because:

1. NebulaResultSetMetaData object is light, it forwards calls to NebulaResultSet
2. Hard to manage cached instance by the client, requires calling release() after usage
3. Stacked ResultSets, getting metadata for second one will overwrite the first